### PR TITLE
add dependency information

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
+  <depend>laser_proc</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This PR adds dependency information to the package so `rosdep install` works properly.